### PR TITLE
Make URL points to correct path

### DIFF
--- a/CentOS-OpsTools.repo
+++ b/CentOS-OpsTools.repo
@@ -5,26 +5,26 @@
 
 [centos-opstools-perfmon-testing]
 name=CentOS-7 - OpsTools Performance monitoring - testing repo
-baseurl=http://cbs.centos.org/repos/opstools7-perfmon-common-testing/$basearch/
+baseurl=http://cbs.centos.org/repos/opstools7-perfmon-common-testing/$basearch/os
 gpgcheck=0
 enabled=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
 [centos-opstools-sensu-testing]
 name=CentOS-7 - OpsTools availability monitoring - testing repo
-baseurl=http://cbs.centos.org/repos/opstools7-sensu-common-testing/$basearch/
+baseurl=http://cbs.centos.org/repos/opstools7-sensu-common-testing/$basearch/os
 gpgcheck=0
 enabled=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
 [centos-opstools-common-testing]
 name=CentOS-7 - OpsTools common testing
-baseurl=http://cbs.centos.org/repos/opstools7-common-common-testing/$basearch/
+baseurl=http://cbs.centos.org/repos/opstools7-common-testing/$basearch/os
 gpgcheck=0
 enabled=1
 
 [centos-opstools-centralized-logging-testing]
 name=CentOS-7 - OpsTools centralized logging common testing
-baseurl=http://cbs.centos.org/repos/opstools7-elastic-common-testing/$basearch/
+baseurl=http://cbs.centos.org/repos/opstools7-elastic-common-testing/$basearch/os
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
Currently the URLs points to an incorrect path making the use of this
.repo file impossible.

All 4 of them were missing the '/os' folder at the end of their path :

http://cbs.centos.org/repos/opstools7-perfmon-common-testing/$basearch

becomes

http://cbs.centos.org/repos/opstools7-perfmon-common-testing/$basearch/os

Also the 'opstools7-common-common-testing' is an incorrect folder name,
the one actually present on cbs is 'opstools7-common-testing'
