### PR TITLE
Use contentdir variable to locate repo

### DIFF
--- a/CentOS-OpsTools.repo
+++ b/CentOS-OpsTools.repo
@@ -11,7 +11,7 @@ enabled=0
 
 [centos-release-opstools]
 name=CentOS-7 - OpsTools - release
-baseurl=http://mirror.centos.org/centos/$releasever/opstools/$basearch/
+baseurl=http://mirror.centos.org/$contentdir/$releasever/opstools/$basearch/
 gpgcheck=1
 enabled=1
 skip_if_unavailable=1

--- a/centos-release-opstools.spec
+++ b/centos-release-opstools.spec
@@ -1,7 +1,7 @@
 Summary: Config to enable the repository for OpsTools SIG
 Name:    centos-release-opstools
 Version: 1
-Release: 7%{?dist}
+Release: 8%{?dist}
 License: GPL
 URL: http://wiki.centos.org/SpecialInterestGroup/OpsTools
 Source0: CentOS-OpsTools.repo
@@ -27,6 +27,9 @@ install -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/pki/rpm-gpg
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-OpsTools
 
 %changelog
+* Tue Jul 17 2018 Tony Breeds <tony@bakeyournoodle.com> - 1.8
+- Use contentdir yum variable
+
 * Thu Mar 23 2017 Matthias Runge <mrunge@redhat.com> - 1.7
 - drop dependency on centos-openstack repos
 


### PR DESCRIPTION
Now that we're publishing OpsTools content for alternate
architectures on the mirror update the release package to use yum
variable to locate that content.